### PR TITLE
qgis version 3.32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,14 @@ RUN apt-get update -y && \
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install wget gnupg -y && \
     wget -O - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --import && \
     gpg --export --armor D155B8E6A419C5BE | apt-key add - && \
+    wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg && \
+    echo "Types: deb deb-src" > /etc/apt/sources.list.d/qgis.sources && \
+    echo "URIs: https://qgis.org/debian" >> /etc/apt/sources.list.d/qgis.sources && \
+    echo "Suites: jammy" >> /etc/apt/sources.list.d/qgis.sources && \
+    echo "Architectures: amd64" >> /etc/apt/sources.list.d/qgis.sources && \
+    echo "Components: main" >> /etc/apt/sources.list.d/qgis.sources && \
+    echo "Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg" >> /etc/apt/sources.list.d/qgis.sources && \    
+    apt-get update && apt-get install -y qgis qgis-plugin-grass && \
     apt-get update && apt-get install -y qgis qgis-plugin-grass && \
     rm -rf /var/lib/apt/lists/*
 
@@ -27,7 +35,7 @@ RUN chmod +x /startapp.sh && \
     
 # Set the name of the application.
 ENV APP_NAME="QGIS"
-ENV APP_VERSION="3.22"
+ENV APP_VERSION="3.32"
 
 ENV KEEP_APP_RUNNING=0
 


### PR DESCRIPTION
This change to the Dockerfile allows to install the latest stable qgis version (3.32).